### PR TITLE
feat: copy public directory to production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
 
 EXPOSE 3000
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Changes

This PR adds the `public` directory copy to the final production stage of the Dockerfile. Next.js applications often have static assets in the `public` folder, and these need to be available in the production container.

### What was changed
- Added `COPY --from=builder /app/public ./public` to the runner stage in the Dockerfile to ensure the public directory is included in the production image if it exists.

### Additional suggestions

I'd also like to suggest considering adding the following for this Dockerfile:

1. **Other package manager support**: Currently, the Dockerfile is hardcoded to use `pnpm`. It would be beneficial to make it more flexible to support `npm`, `pnpm`, `yarn`, and `bun`, similar to the approach used in the official Next.js Docker example: https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile

2. **Bun support**: With the growing adoption of Bun as a faster JavaScript runtime and package manager, it would be great to update this Dockerfile to optionally support Bun.

I had some struggle even with the docker-example for bun while facing into some error with regards to SSR chunks not being found!

Since this repository is still used in the official examples for the documentation of using with SST, I thought I'd help with this